### PR TITLE
Bug fixed for recipe storage

### DIFF
--- a/source/scripts/storage.js
+++ b/source/scripts/storage.js
@@ -70,13 +70,8 @@ storage.addRecipe = function(recipe) {
  * @return {Int} index of the recipe
  */
 storage.getRecipeIndex = function(id) {
-  const currRecipes = storage.getRecipes();
-  for (let i = 0; i < currRecipes.length; i++) {
-    if (currRecipes[i] == id) {
-      return i;
-    }
-  }
-  return -1;
+  const currRecipeIDs = storage.getRecipeIDs();
+  return currRecipeIDs.indexOf(id);
 };
 
 /**
@@ -107,7 +102,6 @@ storage.editRecipe = function(recipe) {
     const newId = storage.addRecipe(recipe);
     return newId;
   } else {
-    currRecipes[indexOfId] = recipe;
     localStorage.setItem(recipe.id, JSON.stringify(recipe));
     return recipe.id;
   }
@@ -156,7 +150,7 @@ storage.unpinRecipe = function(id) {
  * @return {Boolean} whether recipe is pinned
  */
 storage.isPinned = function(id) {
-  return localStorage.getItem(id).pinned == true;
+  return JSON.parse(localStorage.getItem(id)).pinned == true;
 };
 
 /**


### PR DESCRIPTION
Resolved #147 - The bug for editing recipes (edits not showing up) and the recipe localstorage is fixed. Now edits on recipes should work perfectly, and you should see the updated recipe in your Recipe.html page.
Resolved #144 - Some pages doesn't have a description for the recipes, therefore, spoonacular cannot fetch from them. Users have to type in their own descriptions for the recipes instead of relying on Spoonacular.
Credit to Zimo.