### PR TITLE
Fix for storage bug

### DIFF
--- a/source/scripts/storage.js
+++ b/source/scripts/storage.js
@@ -168,7 +168,7 @@ storage.unpinRecipe = function(id) {
  * @return {Boolean} whether recipe is pinned
  */
 storage.isPinned = function(id) {
-  const pinnedRecipe = JSON.parse(localStorage.getItem('pinned'));
+  const pinnedRecipe = JSON.parse(localStorage.getItem('pinned')) || [];
   for (let i = 0; i < pinnedRecipe.length; i++) {
     if (pinnedRecipe[i] == id) {
       return true;


### PR DESCRIPTION
Resolved #159 
When an empty array is returned, pinnedRecipes doesn't work and creates an error. Basically I have to return an empty list whenever there are not pinned recipes.